### PR TITLE
Fcom 308

### DIFF
--- a/Frends.Community.RabbitMQ.Tests/Tests.csproj
+++ b/Frends.Community.RabbitMQ.Tests/Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.13.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -42,11 +43,8 @@
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\packages\RabbitMQ.Client.5.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>
@@ -73,8 +71,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/Frends.Community.RabbitMQ.Tests/UnitTests.cs
+++ b/Frends.Community.RabbitMQ.Tests/UnitTests.cs
@@ -1,32 +1,45 @@
-﻿using System;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using NUnit.Framework;
 using RabbitMQ.Client;
+using System;
+using System.Linq;
 
 namespace Frends.Community.RabbitMQ.Tests
 {
-    [TestClass]
+
+    /// <summary>
+    /// You will need access to RabbitMQ queue, you can create it e.g. by running
+    ///
+    /// docker run -d --hostname my-rabbit -p 9080:15672 -p 5772:5672 -e RABBITMQ_DEFAULT_USER=agent -e RABBITMQ_DEFAULT_PASS=agent123  rabbitmq:3.7-management
+    ///
+    /// In that case URI would be amqp://agent:agent123@localhost:5772
+    /// 
+    /// </summary>
+
+    [TestFixture]
+    // [Ignore("RabbitMQ is not installed on build server.")]
     public class UnitTests
     {
+
         //public const string TestURI = "amqp://user:password@hostname:port/vhost";
-        public const string TestURI = "localhost";
+        public static string TestUri = Environment.GetEnvironmentVariable("HIQ_RABBITMQ_CONNECTIONSTRING");
+        public static string TestHost = "localhost";
 
-        [TestInitialize]
-        public void TestInit()
-        {
+        private WriteInputParams _inputParameters = new WriteInputParams();
+        private WriteInputParamsString _inputParametersString = new WriteInputParamsString();
 
-            //var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = "localhost", QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000 });
-            //var retVal2 = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = true });
+        private ReadInputParams _outputReadParams;
 
-        }
 
         /// <summary>
         /// Deletes test exchange and queue if it exists
         /// </summary>
-        private void DeleteExchangeAndQueue()
+        [TearDown]
+        public void DeleteExchangeAndQueue()
         {
-            var factory = new ConnectionFactory();
-            factory.HostName = "localhost";
+            var factory = new ConnectionFactory
+            {
+                Uri = new Uri(TestUri)
+            };
 
             using (var connection = factory.CreateConnection())
             {
@@ -41,10 +54,13 @@ namespace Frends.Community.RabbitMQ.Tests
         /// <summary>
         /// Creates test exchange and queue
         /// </summary>
-        private void CreateExchangeAndQueue()
+        [SetUp]
+        public void CreateExchangeAndQueue()
         {
-            var factory = new ConnectionFactory();
-            factory.HostName = "localhost";
+            var factory = new ConnectionFactory
+            {
+                Uri = new Uri(TestUri)
+            };
 
             using (var connection = factory.CreateConnection())
             {
@@ -55,102 +71,163 @@ namespace Frends.Community.RabbitMQ.Tests
                     channel.QueueBind("queue", "exchange", routingKey: "");
                 }
             }
+
+            _inputParameters = new WriteInputParams
+            {
+                Data = new byte[] { 0, 1, 2 },
+                HostName = TestHost,
+                RoutingKey = "queue",
+                QueueName = "queue",
+                ConnectWithURI = false,
+                Create = false,
+                Durable = false
+            };
+
+
+
+            _inputParametersString = new WriteInputParamsString
+            {
+                Data = "test message",
+                HostName = TestHost,
+                RoutingKey = "queue",
+                QueueName = "queue",
+                ConnectWithURI = false,
+                Create = false,
+                Durable = false
+            };
+
+            _outputReadParams = new ReadInputParams
+            {
+                HostName = TestHost,
+                QueueName = "queue",
+                AutoAck = ReadAckType.AutoAck,
+                ReadMessageCount = 1,
+                ConnectWithURI = false
+            };
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
         public void TestWriteRead()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0, 1, 2 }, HostName = "localhost", RoutingKey = "queue", QueueName = "queue" });
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = "localhost", QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1 });
+            RabbitMQTask.WriteMessage(_inputParameters);
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 1);
         }
 
-        [TestMethod]
-        [Ignore("Rabbit/*M*/Q is not installed on build server.")]
+        [Test]
         public void TestReadWithAck10()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
+            _outputReadParams.ReadMessageCount = 1000;
+
             for (int i = 0; i < 10; i++)
-                Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0, (byte)(i * i), (byte)i }, HostName = "localhost", RoutingKey = "queue", QueueName = "queue" });
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = "localhost", QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000 });
+            {
+                _inputParameters.Data = new byte[] { 0, (byte)(i * i) };
+                RabbitMQTask.WriteMessage(_inputParameters);
+            }
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 10);
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
         public void TestReadNoAck10()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            for (int i = 0; i < 10; i++)
-                Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0, (byte)(i * i), (byte)i }, HostName = "localhost", RoutingKey = "queue", QueueName = "queue" });
+            _inputParameters.ConnectWithURI = true;
+            _inputParameters.HostName = TestUri;
 
-          var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = "localhost", QueueName = "queue", AutoAck = ReadAckType.AutoNackAndRequeue, ReadMessageCount = 10 });
+            _outputReadParams.ReadMessageCount = 10;
+            _outputReadParams.AutoAck = ReadAckType.AutoNackAndRequeue;
+
+
+            for (int i = 0; i < 10; i++)
+            {
+                _inputParameters.Data = new byte[] { 0, (byte)(i * i), (byte)i };
+
+                RabbitMQTask.WriteMessage(_inputParameters);
+            }
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
 
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 10);
         }
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
-        public void TestWriteReadWithURI()
-        {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
 
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0, 1, 2 }, HostName = TestURI, RoutingKey = "queue", QueueName = "queue", ConnectWithURI = true });
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1, ConnectWithURI = true });
+        [Test]
+        public void TestWriteReadWithUri()
+        {
+            _inputParameters.HostName = TestUri;
+            _inputParameters.ConnectWithURI = true;
+
+            _outputReadParams.ConnectWithURI = true;
+            _outputReadParams.HostName = TestUri;
+
+
+            RabbitMQTask.WriteMessage(_inputParameters);
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
 
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 1);
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
-        public void TestReadWithAck10WithURI()
+        [Test]
+        public void TestReadWithAck10WithUri()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
+            _inputParameters.HostName = TestUri;
+            _inputParameters.ConnectWithURI = true;
+
+
+            _outputReadParams.ConnectWithURI = true;
+            _outputReadParams.HostName = TestUri;
+            _outputReadParams.ReadMessageCount = 10;
+
+
             for (int i = 0; i < 10; i++)
             {
-                Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0, (byte)(i * i), (byte)i }, HostName = TestURI, RoutingKey = "queue", QueueName = "queue", ConnectWithURI = false });
+                _inputParameters.Data = new byte[] { 0, (byte)(i * i), (byte)i };
+
+                RabbitMQTask.WriteMessage(_inputParameters);
             }
 
-
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 10, ConnectWithURI = true });
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
 
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 10);
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
-        public void TestReadNoAck10WithURI()
+        [Test]
+        public void TestReadNoAck10WithUri()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
+            _inputParameters.HostName = TestUri;
+            _inputParameters.ConnectWithURI = true;
+
+
+            _outputReadParams.ConnectWithURI = true;
+            _outputReadParams.AutoAck = ReadAckType.AutoNackAndRequeue;
+            _outputReadParams.HostName = TestUri;
+            _outputReadParams.ReadMessageCount = 10;
+
             for (int i = 0; i < 10; i++)
             {
-                Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0, (byte)(i * i), (byte)i }, HostName = TestURI, RoutingKey = "queue", QueueName = "queue", ConnectWithURI = false });
+                _inputParameters.Data = new byte[] { 0, (byte)(i * i), (byte)i };
+
+                RabbitMQTask.WriteMessage(_inputParameters);
             }
 
-          var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoNackAndRequeue, ReadMessageCount = 10, ConnectWithURI = true });
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
 
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 10);
         }
 
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
         public void TestWriteToNonExistingQueue()
         {
-            DeleteExchangeAndQueue();
             Exception xx = null;
+
+            _inputParameters.QueueName = "queue2"; // Queue won't exist, but don't create it
+
+            _outputReadParams.QueueName = "queue2";
+
             try
             {
-                Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0 }, HostName = TestURI, RoutingKey = "queue", QueueName = "queue", ConnectWithURI = false, Create = false });
+                RabbitMQTask.WriteMessage(_inputParameters);
 
-                var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = false });
+                var _ = RabbitMQTask.ReadMessage(_outputReadParams);
 
             }
             catch (Exception x)
@@ -160,48 +237,38 @@ namespace Frends.Community.RabbitMQ.Tests
             Assert.IsTrue(xx != null);
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
-        public void TestWriteToExistingQueue()
-        {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0 }, HostName = TestURI, RoutingKey = "queue", QueueName = "queue", ConnectWithURI = false, Create = false, Durable = false });
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = false });
-            Assert.IsTrue(retVal != null && retVal.Messages.Count() == 1);
-        }
-
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
         public void TestWriteToExistingExchange()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessage(new WriteInputParams { Data = new byte[] { 0 }, HostName = TestURI, ExchangeName = "exchange", ConnectWithURI = false, Create = false, Durable = false });
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessage(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = false });
+
+            _inputParameters.QueueName = null;
+            _inputParameters.ExchangeName = "exchange";
+
+            RabbitMQTask.WriteMessage(_inputParameters);
+            var retVal = RabbitMQTask.ReadMessage(_outputReadParams);
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 1);
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
         public void TestWriteReadStringToQueue()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessageString(new WriteInputParamsString { Data = "test message", HostName = TestURI, RoutingKey = "queue", QueueName = "queue", ConnectWithURI = false, Create = false, Durable = false });
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessageString(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = false });
+
+            RabbitMQTask.WriteMessageString(_inputParametersString);
+            var retVal = RabbitMQTask.ReadMessageString(_outputReadParams);
+
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 1 && retVal.Messages[0].Data == "test message");
         }
 
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
         public void TestWriteReadStringToExchange()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessageString(new WriteInputParamsString { Data = "test message", HostName = TestURI, ExchangeName = "exchange", RoutingKey = "queue", ConnectWithURI = false, Create = false, Durable = false });
 
-            var retVal = Frends.Community.RabbitMQ.RabbitMQTask.ReadMessageString(new ReadInputParams { HostName = TestURI, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = false });
+            _inputParametersString.QueueName = null;
+            _inputParametersString.ExchangeName = "exchange";
+
+            RabbitMQTask.WriteMessageString(_inputParametersString);
+
+            var retVal = RabbitMQTask.ReadMessageString(new ReadInputParams { HostName = TestUri, QueueName = "queue", AutoAck = ReadAckType.AutoAck, ReadMessageCount = 1000, ConnectWithURI = true });
             Assert.IsTrue(retVal != null && retVal.Messages.Count() == 1 && retVal.Messages[0].Data == "test message");
         }
 
@@ -209,18 +276,15 @@ namespace Frends.Community.RabbitMQ.Tests
         /// <summary>
         /// Used for debugging, if connection is closed and opened for new hostname
         /// </summary>
-        [TestMethod]
-        [Ignore("RabbitMQ is not installed on build server.")]
+        [Test]
+        [Ignore("This test is actually used for debugging while developing task.")]
         public void TestChangingHostName()
         {
-            DeleteExchangeAndQueue();
-            CreateExchangeAndQueue();
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessageString(new WriteInputParamsString { Data = "test message", HostName = "amqp://localhost",  ExchangeName = "exchange", RoutingKey = "queue", ConnectWithURI = true, Create = false, Durable = false });
-            Frends.Community.RabbitMQ.RabbitMQTask.WriteMessageString(new WriteInputParamsString { Data = "test message", HostName = "localhost2", ExchangeName = "exchange", RoutingKey = "queue", ConnectWithURI = false, Create = false, Durable = false });
+            RabbitMQTask.WriteMessageString(new WriteInputParamsString { Data = "test message", HostName = "amqp://localhost", ExchangeName = "exchange", RoutingKey = "queue", ConnectWithURI = true, Create = false, Durable = false });
+            RabbitMQTask.WriteMessageString(new WriteInputParamsString { Data = "test message", HostName = "localhost2", ExchangeName = "exchange", RoutingKey = "queue", ConnectWithURI = false, Create = false, Durable = false });
 
             Assert.IsTrue(true);
         }
-
 
     }
 }

--- a/Frends.Community.RabbitMQ.Tests/packages.config
+++ b/Frends.Community.RabbitMQ.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net452" />
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net452" />
+  <package id="NUnit" version="3.13.1" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="5.1.0" targetFramework="net452" />
 </packages>

--- a/Frends.Community.RabbitMQ/Frends.Community.RabbitMQ.nuspec
+++ b/Frends.Community.RabbitMQ/Frends.Community.RabbitMQ.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Frends.Community.RabbitMQ</id>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <title>FRENDS RabbitMQ Task</title>
     <authors>HiQ Poland</authors>
     <owners />

--- a/Frends.Community.RabbitMQ/RabbitMQTask.cs
+++ b/Frends.Community.RabbitMQ/RabbitMQTask.cs
@@ -15,10 +15,30 @@ namespace Frends.Community.RabbitMQ
         private static IConnection _connection = null;
         private static IModel _channel = null;
 
+        private static bool IsConnectionHostNameChanged(IConnection currentConnetion, string hostName, bool connectWithURI)
+        {
+            // if no current connection, host name is not changed
+            if (currentConnetion == null || currentConnetion.IsOpen == false)
+            {
+                return false;
+            }
+
+            if (connectWithURI)
+            {
+                var newUri = new Uri(hostName);
+                return (currentConnetion.Endpoint.HostName != newUri.Host);
+            }
+            
+            else // connect direct by host name
+            {
+                return (currentConnetion.Endpoint.HostName != hostName);
+            }
+        }
+
         private static void OpenConnectionIfClosed(string hostName, bool connectWithURI)
         {
             //close connection if hostname has changed
-            if(_connection!=null && _connection.Endpoint.HostName != hostName)
+            if (IsConnectionHostNameChanged(_connection, hostName, connectWithURI)) 
             {
                 CloseConnection();
             }

--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.1.0 | Fix nacking while reading multiple messages before it read same message multiple times, because of immediately nacking |
 | 1.2.0 | Write to exchange, but does not implement creating exchange on fly. |
 | 1.3.0 | Message persistence is set to true if durable parameter is true. |
+| 1.5.0 | Fix detecting if host name is changed and connection needs to be closed or reamin open. |
+


### PR DESCRIPTION
Originally pr 15: https://github.com/CommunityHiQ/Frends.Community.RabbitMQ/pull/15

The bug is in the comparison: _connection.Endpoint.HostName != hostName, when connecting with URI. Endpoint.HostName is really only the host name, but hostName parameter contains whole URI. So the comparison is always differs and connection to RabbitMQ is always closed and re-opened every time message is written or read.